### PR TITLE
Adjust header layout and footer info

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,8 +6,8 @@ body {
 } /* #여기에 입력: 기본 폰트 설정 */
 
 header {
-    background: #fff;
-    color: #000;
+    background: #000;
+    color: #fff;
     padding: 20px 0;
 } /* #여기에 입력: 헤더 스타일 */
 
@@ -19,6 +19,8 @@ header h1 {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    max-width: 800px;
+    margin: auto;
 }
 
 .contact {
@@ -30,8 +32,9 @@ nav ul {
     padding: 0;
     display: flex;
     justify-content: center;
-    margin: 10px 0 0 0;
+    margin: 10px auto 0 auto;
     flex-wrap: wrap;
+    max-width: 800px;
 }
 
 nav li {
@@ -39,8 +42,9 @@ nav li {
 }
 
 nav a {
-    color: #333;
+    color: #fff;
     text-decoration: none;
+    font-weight: bold;
 }
 
 section {
@@ -96,7 +100,7 @@ section {
     border: none;
     border-top: 1px dashed #ccc;
     margin: 8px auto;
-    width: 60%;
+    width: 100%;
 }
 
 .edu-basic {

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
     </section>
 
     <footer>
-        <p>&copy; 2025 Myeongjun Kim</p>
+        <p>&copy; 2025 Myeongjun Kim - johnkim682@gmail.com</p>
     </footer>
 
     <script src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- darken header background and keep text white
- center header and nav contents to match main section width
- bold navigation tabs
- extend section dividers to full content width
- show email in footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684862b7d46c832c93208654718a8129