### PR TITLE
Fix awards section layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -147,24 +147,24 @@ footer {
 /* Awards layout */
 .award-entry {
     display: flex;
-    gap: 40px;
-    justify-content: sapce-between;
-    margin-bottom: 15px;
+    justify-content: space-between;
+    margin-bottom: 10px;
 }
 
 .award-year {
     width: 20%;
     font-weight: bold;
-    font-size: 1.2em;
 }
 
-.award-date {
-    width: 50%
-    font-size: 1em;
+.award-year small {
+    font-size: 0.8em;
+    display: block;
 }
 
-.award-info {
-    display: flex;
-    align-items: center;
-    gap: 10px;
+.award-desc {
+    width: 50%;
+}
+
+.award-org {
+    width: 30%;
 }

--- a/index.html
+++ b/index.html
@@ -85,36 +85,44 @@
         <h2>Awards</h2>
         <hr class="section-divider">
         <div class="award-entry">
-            <div class="award-year">2025</div>
-            <div class="award-info"><span class="award-date">2025.3</span> detail</div>
+            <div class="award-year">2025<small>2025.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2024</div>
-            <div class="award-info"><span class="award-date">2024.3</span> detail</div>
+            <div class="award-year">2024<small>2024.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2023</div>
-            <div class="award-info"><span class="award-date">2023.3</span> detail</div>
+            <div class="award-year">2023<small>2023.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2022</div>
-            <div class="award-info"><span class="award-date">2022.3</span> detail</div>
+            <div class="award-year">2022<small>2022.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2021</div>
-            <div class="award-info"><span class="award-date">2021.3</span> detail</div>
+            <div class="award-year">2021<small>2021.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2020</div>
-            <div class="award-info"><span class="award-date">2020.3</span> detail</div>
+            <div class="award-year">2020<small>2020.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2018</div>
-            <div class="award-info"><span class="award-date">2018.3</span> detail</div>
+            <div class="award-year">2018<small>2018.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
         <div class="award-entry">
-            <div class="award-year">2017</div>
-            <div class="award-info"><span class="award-date">2017.3</span> detail</div>
+            <div class="award-year">2017<small>2017.3</small></div>
+            <div class="award-desc">detail</div>
+            <div class="award-org">detail</div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- restore original awards section styles
- update awards section in index to show sub-dates under years

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492afd2ec8832c9883f4ac6575089a