### PR TITLE
Revert to multi-page PDF with proper margins

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,22 +555,35 @@
                 compress: true
             });
 
-            // A4 크기 (mm) - 여백 없음
+            // A4 크기 (mm) - 여백 추가
             const pageWidth = 210;
             const pageHeight = 297;
+            const marginLeft = 10;
+            const marginRight = 10;
+            const marginTop = 10;
+            const marginBottom = 15; // 아래 여백을 조금 더 줌
 
-            // 이미지를 A4 한 페이지에 맞춤 (여백 없음)
-            const imgWidth = pageWidth;
-            const imgHeight = (canvas.height * pageWidth) / canvas.width;
+            // 콘텐츠 영역 계산
+            const contentWidth = pageWidth - marginLeft - marginRight;
+            const contentHeight = pageHeight - marginTop - marginBottom;
 
-            // 한 페이지에 맞추기 위해 높이가 A4를 초과하면 스케일 조정
-            if (imgHeight > pageHeight) {
-                const scale = pageHeight / imgHeight;
-                const scaledWidth = imgWidth * scale;
-                const scaledHeight = pageHeight;
-                pdf.addImage(imgData, 'PNG', 0, 0, scaledWidth, scaledHeight);
-            } else {
-                pdf.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
+            // 이미지 크기 계산
+            const imgWidth = contentWidth;
+            const imgHeight = (canvas.height * contentWidth) / canvas.width;
+
+            let heightLeft = imgHeight;
+            let position = marginTop;
+
+            // 첫 페이지 추가
+            pdf.addImage(imgData, 'PNG', marginLeft, position, imgWidth, imgHeight);
+            heightLeft -= contentHeight;
+
+            // 여러 페이지가 필요한 경우
+            while (heightLeft > 0) {
+                pdf.addPage();
+                position = -(imgHeight - heightLeft) + marginTop;
+                pdf.addImage(imgData, 'PNG', marginLeft, position, imgWidth, imgHeight);
+                heightLeft -= contentHeight;
             }
 
             // PDF 다운로드


### PR DESCRIPTION
- Removed single-page forced scaling to prevent quality degradation
- Added proper margins: 10mm left/right, 10mm top, 15mm bottom
- Content now flows naturally across multiple pages
- Prevents content from being too compressed or pixelated
- Maintains PDF export mode (hides nav/footer, shows email in header)